### PR TITLE
Add JsonInclude annotation and adjust UserMapper

### DIFF
--- a/src/main/java/app/jaba/dtos/AddressDto.java
+++ b/src/main/java/app/jaba/dtos/AddressDto.java
@@ -1,10 +1,12 @@
 package app.jaba.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.io.Serializable;
 import java.util.UUID;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Data Transfer Object for Address")
 public record AddressDto(
         @Schema(description = "Unique identifier of the address", example = "123e4567-e89b-12d3-a456-426614174000", readOnly = true)

--- a/src/main/java/app/jaba/dtos/UserDto.java
+++ b/src/main/java/app/jaba/dtos/UserDto.java
@@ -1,5 +1,6 @@
 package app.jaba.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.lang.NonNull;
 
@@ -7,6 +8,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Set;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Data Transfer Object for User")
 public record UserDto(
         @Schema(description = "Unique identifier of the user", example = "04870a33-235f-4610-a74e-9e057c46a134", readOnly = true)
@@ -25,7 +27,7 @@ public record UserDto(
         String email,
 
         @NonNull
-        @Schema(description = "Password of the user", example = "password123", required = true)
+        @Schema(description = "Password of the user", example = "password123", writeOnly = true)
         String password,
 
         @Schema(description = "Roles assigned to the user")

--- a/src/main/java/app/jaba/mappers/UserMapper.java
+++ b/src/main/java/app/jaba/mappers/UserMapper.java
@@ -11,5 +11,6 @@ public interface UserMapper {
     @Mapping(target = "lastUpdate", ignore = true)
     UserEntity map(UserDto userDto);
 
+    @Mapping(target = "password", ignore = true)
     UserDto map(UserEntity userEntity);
 }


### PR DESCRIPTION
- Add @JsonInclude(JsonInclude.Include.NON_NULL) to AddressDto and UserDto
  to exclude null fields from JSON serialization
- Ignore 'password' field when mapping UserEntity to UserDto in UserMapper
  to prevent sensitive data exposure