### PR TITLE
Refactor UserJdbcRepositoryImpl to use mappers for ResultSet conversion

### DIFF
--- a/src/main/java/app/jaba/mappers/AddressMapper.java
+++ b/src/main/java/app/jaba/mappers/AddressMapper.java
@@ -4,9 +4,30 @@ import app.jaba.dtos.AddressDto;
 import app.jaba.entities.AddressEntity;
 import org.mapstruct.Mapper;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
 @Mapper(componentModel = "spring")
 public interface AddressMapper {
     AddressEntity map(AddressDto addressDto);
 
     AddressDto map(AddressEntity addressEntity);
+
+    default AddressEntity map(ResultSet rs) throws SQLException {
+
+        var addressId = rs.getObject("address_id", UUID.class);
+        if (addressId != null) {
+            AddressEntity address = new AddressEntity();
+            address.setId(addressId);
+            address.setStreet(rs.getString("address_street"));
+            address.setCity(rs.getString("address_city"));
+            address.setState(rs.getString("address_state"));
+            address.setZip(rs.getString("address_zip"));
+            address.setNumber(rs.getString("address_number"));
+            return address;
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/app/jaba/mappers/UserMapper.java
+++ b/src/main/java/app/jaba/mappers/UserMapper.java
@@ -7,6 +7,11 @@ import app.jaba.entities.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 @Mapper(componentModel = "spring", uses = {AddressMapper.class})
 public interface UserMapper {
     @Mapping(target = "id", ignore = true)
@@ -17,4 +22,16 @@ public interface UserMapper {
     UserDto map(UserEntity userEntity);
 
     UpdatePasswordEntity map(UpdatePasswordDto updatePasswordDto);
+
+    @Mapping(target = "address", source = "rs")
+    default UserEntity map(ResultSet rs) throws SQLException {
+        UserEntity user = new UserEntity();
+        user.setId(rs.getObject("user_id", UUID.class));
+        user.setName(rs.getString("user_name"));
+        user.setLogin(rs.getString("user_login"));
+        user.setEmail(rs.getString("user_email"));
+        user.setPassword(rs.getString("user_password"));
+        user.setLastUpdate(rs.getObject("user_last_update", LocalDateTime.class));
+        return user;
+    }
 }

--- a/src/main/java/app/jaba/repositories/UserJdbcRepositoryImpl.java
+++ b/src/main/java/app/jaba/repositories/UserJdbcRepositoryImpl.java
@@ -1,7 +1,8 @@
 package app.jaba.repositories;
 
-import app.jaba.entities.AddressEntity;
 import app.jaba.entities.UserEntity;
+import app.jaba.mappers.AddressMapper;
+import app.jaba.mappers.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -18,6 +19,8 @@ import java.util.UUID;
 public class UserJdbcRepositoryImpl implements UserRepository {
 
     JdbcClient jdbcClient;
+    UserMapper userMapper;
+    AddressMapper addressMapper;
 
     @Override
     public Optional<UserEntity> findById(UUID id) {
@@ -39,26 +42,8 @@ public class UserJdbcRepositoryImpl implements UserRepository {
                 .param("size", size)
                 .param("offset", offset)
                 .query((rs, rowNum) -> {
-                    UserEntity user = new UserEntity();
-                    user.setId(rs.getObject("user_id", UUID.class));
-                    user.setName(rs.getString("user_name"));
-                    user.setLogin(rs.getString("user_login"));
-                    user.setEmail(rs.getString("user_email"));
-                    user.setPassword(rs.getString("user_password"));
-                    user.setLastUpdate(rs.getObject("user_last_update", LocalDateTime.class));
-
-                    var addressId = rs.getObject("address_id", UUID.class);
-                    if (addressId != null) {
-                        AddressEntity address = new AddressEntity();
-                        address.setId(addressId);
-                        address.setStreet(rs.getString("address_street"));
-                        address.setCity(rs.getString("address_city"));
-                        address.setState(rs.getString("address_state"));
-                        address.setZip(rs.getString("address_zip"));
-                        address.setNumber(rs.getString("address_number"));
-                        user.setAddress(address);
-                    }
-
+                    var user = userMapper.map(rs);
+                    user.setAddress(addressMapper.map(rs));
                     return user;
                 })
                 .list();


### PR DESCRIPTION
- Add new map methods in AddressMapper and UserMapper to convert ResultSet to entities
- Update UserJdbcRepositoryImpl to use the new mapper methods
- Simplify the findAll method by leveraging the new mapper functionality
- Improve code readability and maintainability by separating mapping logic